### PR TITLE
Fix cookie-based auth for scene creation

### DIFF
--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
-import { createClientSupabaseClient } from "@/lib/supabase"
+import {
+  createClientSupabaseClient,
+  createClientSupabaseClientWithCookies,
+} from "@/lib/supabase"
 import type { User } from "@supabase/supabase-js"
 
 type AuthContextType = {
@@ -21,7 +24,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<Error | null>(null)
 
   // Inicializar cliente de Supabase una vez
-  const supabase = createClientSupabaseClient()
+  const supabase = createClientSupabaseClientWithCookies()
 
   useEffect(() => {
     // Verificar si hay una sesión activa

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,10 +1,30 @@
-import { createClient } from "@supabase/supabase-js"
+import {
+  createClientComponentClient,
+  createRouteHandlerClient,
+} from "@supabase/auth-helpers-nextjs"
 import type { Database } from "@/types/supabase"
 
 // Singleton para el cliente del lado del cliente
-let clientSupabaseClient: ReturnType<typeof createClient<Database>> | null = null
+let clientSupabaseClient: ReturnType<typeof createClientComponentClient<Database>> | null = null
 
-// Cliente para el lado del servidor
+// Cliente para el lado del servidor con cookies
+export function createServerSupabaseClientWithCookies(cookieStore?: any) {
+  const getCookies = require("next/headers").cookies
+  const store = cookieStore || getCookies()
+  return createRouteHandlerClient<Database>({ cookies: () => store })
+}
+
+// Cliente para el lado del cliente con manejo de cookies
+export function createClientSupabaseClientWithCookies() {
+  if (clientSupabaseClient) return clientSupabaseClient
+  clientSupabaseClient = createClientComponentClient<Database>()
+  return clientSupabaseClient
+}
+
+// Alias mantenido por compatibilidad
+export const createClientSupabaseClient = createClientSupabaseClientWithCookies
+
+// Cliente de servicio con clave de rol
 export function createServerSupabaseClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -13,109 +33,10 @@ export function createServerSupabaseClient() {
     throw new Error("Faltan las variables de entorno de Supabase")
   }
 
-  return createClient<Database>(supabaseUrl, supabaseKey, {
-    auth: {
-      persistSession: false,
-    },
+  const getCookies = require("next/headers").cookies
+  return createRouteHandlerClient<Database>({ cookies: () => getCookies() }, {
+    supabaseUrl,
+    supabaseKey,
+    options: { auth: { persistSession: false } },
   })
-}
-
-// Modificar la función createServerSupabaseClientWithCookies para que acepte cookies como parámetro
-export function createServerSupabaseClientWithCookies(cookieStore?: any) {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  // Use the same anon key as the client to avoid missing env vars in production
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error("Faltan las variables de entorno de Supabase")
-  }
-
-  if (!cookieStore) {
-    // Si no hay cookie store, crear un cliente sin funcionalidad de cookies
-    return createClient<Database>(supabaseUrl, supabaseKey, {
-      auth: {
-        persistSession: false,
-      },
-    })
-  }
-
-  return createClient<Database>(supabaseUrl, supabaseKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-      cookieOptions: {
-        name: "sb-auth-token",
-        path: "/",
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-      },
-    },
-    cookies: {
-      get(name) {
-        return cookieStore.get(name)?.value
-      },
-      set(name, value, options) {
-        try {
-          cookieStore.set({ name, value, ...options })
-        } catch (error) {
-          console.error("Error al establecer cookie:", error)
-        }
-      },
-      remove(name, options) {
-        try {
-          cookieStore.set({ name, value: "", ...options, maxAge: 0 })
-        } catch (error) {
-          console.error("Error al eliminar cookie:", error)
-        }
-      },
-    },
-  })
-}
-
-// Cliente para el lado del cliente
-export function createClientSupabaseClient() {
-  if (clientSupabaseClient) return clientSupabaseClient
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error("Faltan las variables de entorno de Supabase")
-  }
-
-  clientSupabaseClient = createClient<Database>(supabaseUrl, supabaseKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-    },
-  })
-
-  return clientSupabaseClient
-}
-
-// Función que faltaba y causaba el error
-export function createClientSupabaseClientWithCookies() {
-  if (clientSupabaseClient) return clientSupabaseClient
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error("Faltan las variables de entorno de Supabase")
-  }
-
-  clientSupabaseClient = createClient<Database>(supabaseUrl, supabaseKey, {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true,
-      cookieOptions: {
-        name: "sb-auth-token",
-        path: "/",
-        sameSite: "lax",
-        secure: process.env.NODE_ENV === "production",
-      },
-    },
-  })
-
-  return clientSupabaseClient
 }


### PR DESCRIPTION
## Summary
- use Supabase auth helpers to manage auth tokens via cookies
- initialize Supabase client with cookies in Auth context

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843c8ef9f24832aa7b51f6aef6a9d1b