### PR TITLE
Fix scene deletion persistance

### DIFF
--- a/app/api/projects/[projectId]/scenes/[sceneId]/route.ts
+++ b/app/api/projects/[projectId]/scenes/[sceneId]/route.ts
@@ -1,0 +1,37 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerSupabaseClientWithCookies } from "@/lib/supabase";
+import { getProject } from "@/lib/projects";
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { projectId: string; sceneId: string } },
+) {
+  try {
+    const { projectId, sceneId } = params;
+    const cookieStore = cookies();
+
+    // Ensure the user has access to this project
+    await getProject(projectId, cookieStore);
+
+    const supabase = createServerSupabaseClientWithCookies(cookieStore);
+    const { error } = await supabase
+      .from("scenes")
+      .delete()
+      .eq("id", sceneId)
+      .eq("project_id", projectId);
+
+    if (error) {
+      console.error("Error deleting scene:", error.message);
+      return NextResponse.json(
+        { error: `Error al eliminar escena: ${error.message}` },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error("Error in DELETE scene API:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/components/script-editor.tsx
+++ b/components/script-editor.tsx
@@ -454,8 +454,28 @@ export function ScriptEditor({
     }
   }
 
-  const deleteScene = (sceneId: string) => {
+  const deleteScene = async (sceneId: string) => {
     if (scenesArray.length <= 1) return
+
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/scenes/${sceneId}`,
+        { method: "DELETE" },
+      )
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || "No se pudo eliminar la escena")
+      }
+    } catch (error: any) {
+      console.error("Error deleting scene:", error)
+      toast({
+        title: "Error al eliminar escena",
+        description: error.message,
+        variant: "destructive",
+      })
+      return
+    }
+
     const updatedScenes = scenesArray.filter((s) => s.id !== sceneId)
     setScenesArray(updatedScenes)
 

--- a/lib/scenes.ts
+++ b/lib/scenes.ts
@@ -163,3 +163,25 @@ export async function flipScenesOrder(projectId: string, sceneIds: string[]) {
     return { success: false, error: `Error al invertir escenas: ${error.message}` }
   }
 }
+
+// Function to delete a scene
+export async function deleteScene(sceneId: string, projectId: string) {
+  try {
+    const supabase = createClientComponentClient<Database>();
+    const { error } = await supabase
+      .from("scenes")
+      .delete()
+      .eq("id", sceneId)
+      .eq("project_id", projectId);
+
+    if (error) {
+      console.error("Error deleting scene:", error);
+      throw new Error(`Error al eliminar la escena: ${error.message}`);
+    }
+
+    return true;
+  } catch (error: any) {
+    console.error("Error in deleteScene:", error);
+    throw new Error(`Error al eliminar la escena: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to delete scenes from projects
- expose `deleteScene` helper in `lib/scenes`
- call the API in `deleteScene` handler in `ScriptEditor`

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684473377b94832ab555a766a644502d